### PR TITLE
OchEBTv3/Remove footer links

### DIFF
--- a/src/templateParts/Footer.vue
+++ b/src/templateParts/Footer.vue
@@ -20,42 +20,7 @@
           </div>
         </div>
         <div class="col-lg-6">
-          <ul
-            class="nav nav-footer justify-content-center justify-content-lg-end"
-          >
-            <li class="nav-item">
-              <a
-                href="https://www.creative-tim.com"
-                class="nav-link text-muted"
-                target="_blank"
-                >Creative Tim</a
-              >
-            </li>
-            <li class="nav-item">
-              <a
-                href="https://www.creative-tim.com/presentation"
-                class="nav-link text-muted"
-                target="_blank"
-                >About Us</a
-              >
-            </li>
-            <li class="nav-item">
-              <a
-                href="https://www.creative-tim.com/blog"
-                class="nav-link text-muted"
-                target="_blank"
-                >Blog</a
-              >
-            </li>
-            <li class="nav-item">
-              <a
-                href="https://www.creative-tim.com/license"
-                class="nav-link pe-0 text-muted"
-                target="_blank"
-                >License</a
-              >
-            </li>
-          </ul>
+          <!-- Removed the ul with nav links -->
         </div>
       </div>
     </div>


### PR DESCRIPTION
Removed footer links ('Creative Tim,' 'About Us,' 'Blog,' 'License') from Footer.vue in src/templateParts as per Trello task #456. Tested locally to confirm the links are no longer visible.